### PR TITLE
Silence glib warnings regarding GOptionFlags.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -116,28 +116,28 @@ gboolean parse_options(int argc, char* argv[])
 	{
 		{
 			"daemon", 'd',
-			G_OPTION_FLAG_NO_ARG,
+			0,
 			G_OPTION_ARG_NONE,
 			&daemon, _("Run as daemon"),
 			NULL
 		},
 		{
 			"no-icon", 'n',
-			G_OPTION_FLAG_NO_ARG,
+			0,
 			G_OPTION_ARG_NONE,
 			&icon, _("Do not use status icon (Ctrl-Alt-P for menu)"),
 			NULL
 		},
 		{
 			"clipboard", 'c',
-			G_OPTION_FLAG_NO_ARG,
+			0,
 			G_OPTION_ARG_NONE,
 			&clipboard, _("Print clipboard contents"),
 			NULL
 		},
 		{
 			"primary", 'p',
-			G_OPTION_FLAG_NO_ARG,
+			0,
 			G_OPTION_ARG_NONE,
 			&primary, _("Print primary contents"),
 			NULL


### PR DESCRIPTION
These warnings:
GLib-WARNING **: goption.c:2168: ignoring no-arg, optional-arg or filename flags (8) on option of type 0
