### PR TITLE
Updated .gitignore: Ignore autogenerated file - compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ po/Makevars.template
 *~
 Makefile
 Makefile.in
+compile


### PR DESCRIPTION
`compile` is generated while building. 