### PR TITLE
Returning if string dooesn't exist on stdin. Fixes "Binding failed"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1011,6 +1011,7 @@ int main(int argc, char **argv) {
 				return 0;
 			}
 			g_string_free(piped_string, TRUE);
+			return -1;
 		}
 	}
 


### PR DESCRIPTION
`clipit` gives a "Binding ... failed" warning if the input of pipe doesn't exist.
eg.
`cat non_existent_file | clipit` gives you the warning.
Returning -1 when such a thing happens before it executes `clipit_init()`.
 Maybe you could add a separate warning message here.