### PR TITLE
Increase DEF_HISTORY_LIMIT to 1000 and make GtkSpinButton use it

### DIFF
--- a/src/preferences.c
+++ b/src/preferences.c
@@ -825,7 +825,7 @@ void show_preferences(gint tab) {
   label = gtk_label_new(_("Items in history:"));
   gtk_misc_set_alignment((GtkMisc*)label, 0.0, 0.50);
   gtk_box_pack_start((GtkBox*)hbox, label, FALSE, FALSE, 0);
-  adjustment = gtk_adjustment_new(25, 5, 1000, 1, 10, 0);
+  adjustment = gtk_adjustment_new(25, 5, DEF_HISTORY_LIMIT, 1, 10, 0);
   history_spin = gtk_spin_button_new((GtkAdjustment*)adjustment, 0.0, 0);
   gtk_spin_button_set_update_policy((GtkSpinButton*)history_spin, GTK_UPDATE_IF_VALID);
   gtk_box_pack_start((GtkBox*)hbox, history_spin, FALSE, FALSE, 0);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
 #define DEF_SAVE_URIS                 TRUE
 #define DEF_SAVE_HISTORY              TRUE
 #define DEF_USE_RMB_MENU              FALSE
-#define DEF_HISTORY_LIMIT             50
+#define DEF_HISTORY_LIMIT             1000
 #define DEF_HISTORY_TIMEOUT           FALSE
 #define DEF_HISTORY_TIMEOUT_SECONDS   30
 #define DEF_ITEMS_MENU                20


### PR DESCRIPTION
Adjustment for history_spin button had hardcoded max value (1000) but DEF_HISTORY_LIMIT was 50 so even if the user selected larger value than 50, the application does not respect it.
Now history_spin use DEF_HISTORY_LIMIT as max value and DEF_HISTORY_LIMIT increased to 1000