### PR TITLE
Fix history index when selected from keyboard

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -713,12 +713,9 @@ gboolean selected_by_digit(const GtkWidget *history_menu, const GdkEventKey *eve
     case XK_KP_9:
 	  selection = 9;
       break;
-    case XK_0:
-    case XK_KP_0:
-	  selection = 0;
-      break;
   }
-  if (selection >= 0) {
+  if (selection > 0) {
+	--selection; // The item index is counted from 0, but listed on screen from 1
 	item_selected((GtkMenuItem*)history_menu, GINT_TO_POINTER(selection));
 	gtk_widget_destroy(history_menu);
 	return TRUE;


### PR DESCRIPTION
Hi!

The history items are listed on screen with numbers starting from 1, but they are counted from 0 when selected from keyboard. For this reason, if some number key "N" is pressed, the item shown as "N+1" is selected. (See issue: #155 )

This pull request fixes the issue, respecting the 1-based index shown on screen.

Cheers!