### PR TITLE
Fix segmentation fault when special keys are pressed on history search

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -602,8 +602,6 @@ static gboolean menu_key_pressed(GtkWidget *history_menu, GdkEventKey *event, gp
  * match should be a pointer to the first character of the matched text.
  */
 void underline_match(char* match, GtkMenuItem* menu_item, const gchar* menu_label) {
-  if (!match)
-    return;
 
   int start = match - menu_label;
   int end = start + strlen(input_buffer);

--- a/src/main.c
+++ b/src/main.c
@@ -653,7 +653,7 @@ gboolean selected_by_input(const GtkWidget *history_menu, const GdkEventKey *eve
     gtk_menu_item_deselect(menu_item);
 
     match = strcasestr(menu_label, input_buffer);
-    if (match) {
+    if (match && *match!='\0') {
       if (!first_match)
         first_match = menu_item;
       match_count++;


### PR DESCRIPTION
Hello!

As pointed out by @ragnarov on issue #168, ClipIt crashes when the history shortcut is pressed and the history is already open. The crash actually happens whenever a special character such as Ctrl, Alt, Backspace or the arrow keys are pressed, since it causes the pointer `match` inside `selected_from_input()` to point to an empty char string. Then it propagates into `undeline_match()`, and causes a segmentation fault.

The program already performs a validity check for `match` inside `selected_by_input()` by using a conditional `if (match)` before calling `underline_match()`. However, it only catches the case when `match` is a null pointer.

This pull request is quite simple and consists in two commits. The first commit extends the validity check on `selected_by_input()` to ensure that `match` points to a non-empty char string, thus fixing all the related crash cases I could find while preserving the right character count for posterior key presses. The second commit removes a redundant `if (match)` included inside `underline_match()`, which is unnecessary since the function is only called after this condition is already ensured.

Cheers!