### PR TITLE
Added "&" to the "Exec" lines of clipit-startup.desktop.in and clipit…

### DIFF
--- a/data/clipit-startup.desktop.in
+++ b/data/clipit-startup.desktop.in
@@ -2,7 +2,7 @@
 _Name=ClipIt
 _Comment=Clipboard Manager
 Icon=clipit-trayicon
-Exec=clipit
+Exec=clipit &
 Terminal=false
 Type=Application
 OnlyShowIn=GNOME;XFCE;LXDE;Unity;

--- a/data/clipit.desktop.in
+++ b/data/clipit.desktop.in
@@ -2,7 +2,7 @@
 _Name=ClipIt
 _Comment=Clipboard Manager
 Icon=clipit-trayicon-offline
-Exec=clipit
+Exec=clipit &
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;Application;Utility;


### PR DESCRIPTION
….desktop.in.: Wed 21 Apr 2021 02:55:28 PM CDT

If the `clipit` binary is executed from a *.desktop* file (especially as an autostart item) then it will not run properly; not showing the system tray icon and no hotkeys are accessible, but the process is running. 

This is an easy fix that I've tested on 2 distros, *Ubuntu* and *Linux Lite*, in *Gnome* and *Plasma*.