### PR TITLE
Fix building with C99 compilers

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,7 @@
 #include <ctype.h>
 #include <stdbool.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #define ICON "clipit-trayicon"
 #define ICON_OFFLINE "clipit-trayicon-offline"

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -80,6 +80,8 @@ void show_preferences(gint tab);
 
 void init_purge_timer();
 
+void init_history_timeout_timer();
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
C99 removed implicit function declarations.  Include <sys/stat.h> for the umask function, and init_history_timeout_timer because it is used in main.c.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
