### PR TITLE
Fix function prototype for g_timer_add family for C23

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -331,7 +331,7 @@ void search_window_response(GtkDialog *dialog, gint response_id, gpointer user_d
 }
 
 /* Shows the search dialog */
-gboolean show_search()
+gboolean show_search(gpointer user_data)
 {
   /* Prevent multiple instances */
   if(gtk_grab_get_current()) {

--- a/src/manage.h
+++ b/src/manage.h
@@ -24,7 +24,7 @@
 
 G_BEGIN_DECLS
 
-gboolean show_search();
+gboolean show_search(gpointer);
 void remove_all_selected(gpointer);
 
 G_END_DECLS

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -430,7 +430,7 @@ static void start_purge_timer(gint timeout_seconds);
 static void stop_purge_timer();
 
 /* Purge history if history_timeout is enabled. This function is called every prefs.history_timeout_seconds */
-static gboolean purge_history() {
+static gboolean purge_history(gpointer user_data) {
     if (prefs.history_timeout) {
       g_list_free(history);
       history = NULL;


### PR DESCRIPTION
g_timer_add or g_timeout_add_seconds manual says that the second argument must have type of GSourceFunc, i.e. function with one gpointer argument returning gboolean.

Fixing so, unless compilation fails with C23.